### PR TITLE
Response time ananlysis

### DIFF
--- a/Whatsapp-Chat-Analyser-main/app.py
+++ b/Whatsapp-Chat-Analyser-main/app.py
@@ -136,4 +136,29 @@ if uploaded_file is not None:
         st.subheader("Most Common Flagged Words")
         st.dataframe(toxic_words_df)
 
+        # Response time Analysis
+        st.title("Response Time Analysis (Who Replies Faster)")
 
+        gap_threshold = st.slider(
+            "Exclude gaps longer than (hours)",
+            min_value=1,
+            max_value=24,
+            value=6
+        )
+
+        reply_df = helper.reply_time_analysis(selected_user, df, gap_threshold)
+
+        st.subheader("Median Reply Time per User (in minutes)")
+        st.dataframe(reply_df)
+
+        # Optional Bar Chart
+        if not reply_df.empty:
+            fig, ax = plt.subplots()
+            ax.bar(
+                reply_df['user'],
+                reply_df['Median Reply Time (minutes)']
+            )
+            plt.xticks(rotation=45)
+            ax.set_ylabel("Minutes")
+            ax.set_title("Median Reply Time")
+            st.pyplot(fig)

--- a/quant_finance/quantwise-frontend/src/pages/AnalysePortfolio.jsx
+++ b/quant_finance/quantwise-frontend/src/pages/AnalysePortfolio.jsx
@@ -11,6 +11,13 @@ const DEFAULT_HOLDINGS = [
   { symbol: 'TSLA', allocation: '25' },
 ];
 
+const getDiversificationLabel = (score) => {
+  if (score >= 0.6) return { text: 'High', color: 'text-emerald-300' };
+  if (score >= 0.3) return { text: 'Medium', color: 'text-amber-300' };
+  return { text: 'Low', color: 'text-rose-300' };
+};
+
+
 const PortfolioAnalyzer = () => {
   const [holdings, setHoldings] = useState(DEFAULT_HOLDINGS);
   const [analysis, setAnalysis] = useState(null);
@@ -223,7 +230,7 @@ const PortfolioAnalyzer = () => {
               </h3>
 
               {analysis ? (
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs sm:text-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 text-xs sm:text-sm">
                   <div className="rounded-xl bg-slate-900/80 border border-emerald-500/40 px-3 py-3 flex flex-col gap-1">
                     <span className="text-slate-400">Expected annual return</span>
                     <span className="text-emerald-300 text-lg font-semibold">
@@ -242,6 +249,19 @@ const PortfolioAnalyzer = () => {
                       {analysis.portfolio_metrics.sharpe_ratio.toFixed(2)}
                     </span>
                   </div>
+                  {analysis.diversification && (() => {
+                  const { diversification_score } = analysis.diversification;
+                  const label = getDiversificationLabel(diversification_score);
+
+                  return (
+                  <div className="rounded-xl bg-slate-900/80 border border-indigo-500/40 px-3 py-3 flex flex-col gap-1">
+                  <span className="text-slate-400">Diversification score</span>
+                  <span className={`${label.color} text-lg font-semibold`}>
+                    {diversification_score.toFixed(2)} ({label.text})
+                    </span>
+                  </div>
+                );
+          })()}
                 </div>
               ) : (
                 <p className="text-xs sm:text-sm text-slate-400">


### PR DESCRIPTION
Closes Issue #2 
### This PR introduces Response Time Analysis (Who Replies Faster) to the WhatsApp Chat Analyzer.

- The feature calculates the median reply time (in minutes) for each user by detecting sender change points and computing time gaps between consecutive messages.

---

### How It Works

- Messages are sorted chronologically.

- Reply time is calculated only when the sender changes.

- Consecutive messages from the same sender are ignored.

- Long gaps (greater than the configurable threshold) are excluded.

- Median reply time is computed per user.

---

### Files Modified

- helper.py : Added reply_time_analysis() function

- app.py

-> Added Streamlit UI section:

-> Gap threshold slider

-> Reply time table

-> Bar chart visualization


---

<img width="1299" height="473" alt="Screenshot 2026-02-11 at 5 51 37 PM" src="https://github.com/user-attachments/assets/5e1c22ce-4d92-4de1-a54c-f1882b48aebd" />

<img width="1338" height="641" alt="Screenshot 2026-02-11 at 5 51 55 PM" src="https://github.com/user-attachments/assets/0a75c176-9f4d-4c5e-91d1-ef6d00c1312e" />

[sample.txt](https://github.com/user-attachments/files/25233592/sample.txt)

