### PR TITLE
Add multi-chat upload support with side-by-side comparison

### DIFF
--- a/Whatsapp-Chat-Analyser-main/helper.py
+++ b/Whatsapp-Chat-Analyser-main/helper.py
@@ -43,8 +43,13 @@ def create_wordcloud(selected_user,df):
                 y.append(word)
         return " ".join(y)
     #creating image
-    temp['message'] = temp['message'].apply(remove_stop_words)
-    df_wc=wc.generate(temp['message'].str.cat(sep=" "))
+    temp['message'] = temp['message'].fillna("").astype(str).apply(remove_stop_words)
+
+    # If no valid messages remain, return empty wordcloud safely
+    if temp['message'].str.strip().eq("").all():
+        return wc.generate("No Data")
+
+    df_wc = wc.generate(temp['message'].str.cat(sep=" "))
 
     return df_wc
 

--- a/Whatsapp-Chat-Analyser-main/preprocessor.py
+++ b/Whatsapp-Chat-Analyser-main/preprocessor.py
@@ -2,7 +2,7 @@ import re #regular expressions
 import pandas as pd
 
 def preprocessor(data):
-    pattern='\d{1,2}/\d{1,2}/\d{2,4},\s\d{1,2}:\d{2}\s?[ap]m\s-\s'
+    pattern = r'\d{1,2}/\d{1,2}/\d{2,4},\s\d{1,2}:\d{2}\s?[apAP][mM]\s-\s'
 
     messages= re.split(pattern,data)[1:]
     dates=re.findall(pattern,data)


### PR DESCRIPTION
This PR introduces support for uploading and analyzing up to three WhatsApp chat files simultaneously. Previously, the application supported analysis of only a single chat file at a time. With this enhancement, users can now perform comparative analysis across multiple chats within the same interface.

The file uploader was updated to accept multiple files using accept_multiple_files=True. Each uploaded file is processed independently through the existing preprocessing pipeline, ensuring no changes were required to the core logic inside preprocessor.py or helper.py. The parsed DataFrames are stored in a dictionary structure, enabling clean separation of chat data and reuse of the same analytical functions per chat.

For the user interface, a conditional rendering approach was implemented:
	•	If a single chat is uploaded, the application preserves the original full detailed dashboard (statistics, timelines, heatmap, word cloud, emoji analysis, etc.).
	•	If two or more chats are uploaded (up to three), the app switches to comparison mode and displays summary statistics side-by-side using Streamlit columns.

This ensures backward compatibility while extending functionality.

Additionally, safeguards were introduced to gracefully handle empty datasets and prevent runtime errors during visualization rendering (e.g., empty heatmaps or word frequency plots). These checks improve overall robustness and user experience.
<img width="1298" height="956" alt="Screenshot 2026-02-22 at 7 39 46 PM" src="https://github.com/user-attachments/assets/5daf4e7c-cddf-4b12-a0d0-1b39438b1a69" />
<img width="1298" height="956" alt="Screenshot 2026-02-22 at 7 39 41 PM" src="https://github.com/user-attachments/assets/4bea5439-f586-42b1-9e2e-10726e47e98a" />
![Screenshot 2026-02-22 at 7 35 59 PM](https://github.com/user-attachments/assets/eb1fe2f0-cbcb-412f-859e-6e34f5e99107)

