### PR TITLE
 added max drawdown and VaR metrics with color-coded display

### DIFF
--- a/quant_finance/api.py
+++ b/quant_finance/api.py
@@ -117,7 +117,24 @@ def compute_diversification_and_correlation(
         "correlation_matrix": corr_df.round(2).to_dict(),
     }
 
+def compute_max_drawdown(port_daily_returns: np.ndarray) -> float:
+    """Compute maximum drawdown from a series of daily returns."""
+    cumulative = np.cumprod(1 + port_daily_returns)
+    running_max = np.maximum.accumulate(cumulative)
+    drawdown = (cumulative - running_max) / running_max
+    max_dd = np.min(drawdown)          # most negative value
+    return float(max_dd)               # e.g. -0.25 for 25% drawdown
 
+
+def compute_var(port_daily_returns: np.ndarray, confidence: float = 0.95) -> float:
+    """
+    Compute Value at Risk (VaR) at a given confidence level using the historical method.
+    Returns a positive number representing the potential loss (e.g., 0.05 for 5% loss).
+    """
+    sorted_returns = np.sort(port_daily_returns)
+    index = int((1 - confidence) * len(sorted_returns))
+    var = -sorted_returns[index]       # VaR as a positive loss percentage
+    return float(var)
 
 def compute_metrics(portfolio: List[Dict[str, float]]) -> Dict:
     """
@@ -166,6 +183,9 @@ def compute_metrics(portfolio: List[Dict[str, float]]) -> Dict:
 
     # Portfolio daily returns as weighted sum
     port_daily_returns = daily_returns @ weights  # (T-1,)
+    
+    max_drawdown = compute_max_drawdown(port_daily_returns)
+    var_95 = compute_var(port_daily_returns, confidence=0.95)
 
     # Annualised metrics (assuming 252 trading days)
     mean_daily = float(np.mean(port_daily_returns))
@@ -188,16 +208,19 @@ def compute_metrics(portfolio: List[Dict[str, float]]) -> Dict:
         }
         for d, v in zip(value_dates, port_values)
     ]
-
     return {
     "portfolio_metrics": {
         "expected_return": round(expected_return, 4),
         "volatility": round(volatility, 4),
         "sharpe_ratio": round(sharpe, 2),
+        "max_drawdown": round(max_drawdown, 4),   # <-- new
+        "var_95": round(var_95, 4)                # <-- new
     },
     "diversification": diversification,
     "history": history,
 }
+    
+
 
 
 

--- a/quant_finance/quantwise-frontend/src/pages/AnalysePortfolio.jsx
+++ b/quant_finance/quantwise-frontend/src/pages/AnalysePortfolio.jsx
@@ -16,7 +16,20 @@ const getDiversificationLabel = (score) => {
   if (score >= 0.3) return { text: 'Medium', color: 'text-amber-300' };
   return { text: 'Low', color: 'text-rose-300' };
 };
+const getDrawdownLabel = (drawdown) => {
+  // drawdown is negative, e.g., -0.15
+  const absDrawdown = Math.abs(drawdown);
+  if (absDrawdown < 0.10) return { text: 'Low', color: 'text-emerald-300' };
+  if (absDrawdown < 0.20) return { text: 'Medium', color: 'text-amber-300' };
+  return { text: 'High', color: 'text-rose-300' };
+};
 
+const getVarLabel = (varValue) => {
+  // varValue is positive loss percentage, e.g., 0.05 for 5%
+  if (varValue < 0.05) return { text: 'Low', color: 'text-emerald-300' };
+  if (varValue < 0.10) return { text: 'Medium', color: 'text-amber-300' };
+  return { text: 'High', color: 'text-rose-300' };
+};
 
 const PortfolioAnalyzer = () => {
   const [holdings, setHoldings] = useState(DEFAULT_HOLDINGS);
@@ -230,38 +243,100 @@ const PortfolioAnalyzer = () => {
               </h3>
 
               {analysis ? (
-                <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 text-xs sm:text-sm">
-                  <div className="rounded-xl bg-slate-900/80 border border-emerald-500/40 px-3 py-3 flex flex-col gap-1">
-                    <span className="text-slate-400">Expected annual return</span>
-                    <span className="text-emerald-300 text-lg font-semibold">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-sm sm:text-base">
+                  {/* Expected annual return */}
+                  <div className="rounded-xl bg-slate-900/80 border border-emerald-500/40 px-5 py-5 flex flex-col gap-2">
+                    <span className="text-slate-400 text-xs sm:text-sm">Expected annual return</span>
+                    <span className="text-emerald-300 text-2xl sm:text-3xl font-semibold">
                       {(analysis.portfolio_metrics.expected_return * 100).toFixed(2)}%
                     </span>
                   </div>
-                  <div className="rounded-xl bg-slate-900/80 border border-amber-500/40 px-3 py-3 flex flex-col gap-1">
-                    <span className="text-slate-400">Volatility (risk)</span>
-                    <span className="text-amber-300 text-lg font-semibold">
+
+                  {/* Volatility */}
+                  <div className="rounded-xl bg-slate-900/80 border border-amber-500/40 px-5 py-5 flex flex-col gap-2">
+                    <span className="text-slate-400 text-xs sm:text-sm">Volatility (risk)</span>
+                    <span className="text-amber-300 text-2xl sm:text-3xl font-semibold">
                       {(analysis.portfolio_metrics.volatility * 100).toFixed(2)}%
                     </span>
                   </div>
-                  <div className="rounded-xl bg-slate-900/80 border border-sky-500/40 px-3 py-3 flex flex-col gap-1">
-                    <span className="text-slate-400">Sharpe ratio</span>
-                    <span className="text-sky-300 text-lg font-semibold">
+
+                  {/* Sharpe ratio */}
+                  <div className="rounded-xl bg-slate-900/80 border border-sky-500/40 px-5 py-5 flex flex-col gap-2">
+                    <span className="text-slate-400 text-xs sm:text-sm">Sharpe ratio</span>
+                    <span className="text-sky-300 text-2xl sm:text-3xl font-semibold">
                       {analysis.portfolio_metrics.sharpe_ratio.toFixed(2)}
                     </span>
                   </div>
-                  {analysis.diversification && (() => {
-                  const { diversification_score } = analysis.diversification;
-                  const label = getDiversificationLabel(diversification_score);
 
-                  return (
-                  <div className="rounded-xl bg-slate-900/80 border border-indigo-500/40 px-3 py-3 flex flex-col gap-1">
-                  <span className="text-slate-400">Diversification score</span>
-                  <span className={`${label.color} text-lg font-semibold`}>
-                    {diversification_score.toFixed(2)} ({label.text})
-                    </span>
-                  </div>
-                );
-          })()}
+                  {/* Max Drawdown */}
+                  {analysis.portfolio_metrics.max_drawdown !== undefined && (() => {
+                    const ddLabel = getDrawdownLabel(analysis.portfolio_metrics.max_drawdown);
+                    const colorMap = {
+                      Low: 'text-emerald-300',
+                      Medium: 'text-amber-300',
+                      High: 'text-rose-300'
+                    };
+                    return (
+                      <div className="rounded-xl bg-slate-900/80 border border-purple-500/40 px-5 py-5 flex flex-col gap-2">
+                        <span className="text-slate-400 text-xs sm:text-sm">Max Drawdown</span>
+                        <div className="flex items-baseline flex-wrap gap-2">
+                          <span className={`${colorMap[ddLabel.text]} text-2xl sm:text-3xl font-semibold`}>
+                            {(Math.abs(analysis.portfolio_metrics.max_drawdown) * 100).toFixed(1)}%
+                          </span>
+                          <span className={`${colorMap[ddLabel.text]} text-sm sm:text-base font-medium px-2 py-1 rounded-full bg-slate-800/60`}>
+                            {ddLabel.text}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })()}
+
+                  {/* VaR (95%) */}
+                  {analysis.portfolio_metrics.var_95 !== undefined && (() => {
+                    const varLabel = getVarLabel(analysis.portfolio_metrics.var_95);
+                    const colorMap = {
+                      Low: 'text-emerald-300',
+                      Medium: 'text-amber-300',
+                      High: 'text-rose-300'
+                    };
+                    return (
+                      <div className="rounded-xl bg-slate-900/80 border border-pink-500/40 px-5 py-5 flex flex-col gap-2">
+                        <span className="text-slate-400 text-xs sm:text-sm">VaR (95%)</span>
+                        <div className="flex items-baseline flex-wrap gap-2">
+                          <span className={`${colorMap[varLabel.text]} text-2xl sm:text-3xl font-semibold`}>
+                            {(analysis.portfolio_metrics.var_95 * 100).toFixed(1)}%
+                          </span>
+                          <span className={`${colorMap[varLabel.text]} text-sm sm:text-base font-medium px-2 py-1 rounded-full bg-slate-800/60`}>
+                            {varLabel.text}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })()}
+
+                  {/* Diversification score */}
+                  {analysis.diversification && (() => {
+                    const { diversification_score } = analysis.diversification;
+                    const label = getDiversificationLabel(diversification_score);
+                    const colorMap = {
+                      Low: 'text-emerald-300',
+                      Medium: 'text-amber-300',
+                      High: 'text-rose-300'
+                    };
+                    return (
+                      <div className="rounded-xl bg-slate-900/80 border border-indigo-500/40 px-5 py-5 flex flex-col gap-2">
+                        <span className="text-slate-400 text-xs sm:text-sm">Diversification score</span>
+                        <div className="flex items-baseline flex-wrap gap-2">
+                          <span className={`${colorMap[label.text]} text-2xl sm:text-3xl font-semibold`}>
+                            {diversification_score.toFixed(2)}
+                          </span>
+                          <span className={`${colorMap[label.text]} text-sm sm:text-base font-medium px-2 py-1 rounded-full bg-slate-800/60`}>
+                            {label.text}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })()}
                 </div>
               ) : (
                 <p className="text-xs sm:text-sm text-slate-400">


### PR DESCRIPTION
This PR adds two new risk metrics – **Max Drawdown** and **Value at Risk (VaR, 95%)** – to the portfolio analyzer, and improves the visual layout for better readability.

### Backend Changes
- Added `compute_max_drawdown` and `compute_var` helper functions in `api.py`.
- Updated `compute_metrics` to return `max_drawdown` and `var_95` inside `portfolio_metrics`.

here is the ss of website after changes:
<img width="1024" height="891" alt="image" src="https://github.com/user-attachments/assets/7863131f-07e3-4029-bc13-086839cdac60" />

